### PR TITLE
Adding arm64 build and multiarch manifest to the dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,6 +331,7 @@ workflows:
           context:
             - DockerHub
           requires:
+            - build
             - build-arm64
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,6 +294,7 @@ jobs:
           at: .
       - run: |
           export VERSION=`./scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
+          echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
           docker manifest create $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
           docker manifest push $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian
           docker manifest create $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,11 +295,17 @@ jobs:
       - run: |
           export VERSION=`./scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
           echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
-          docker manifest create $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
-          docker manifest push $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian
+          docker manifest create $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64          
           docker manifest create $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
+          docker manifest push $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian
           docker manifest push $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH
-
+          # If the branch is main, add manifests with $IMAGE_NAME:$VERSION and $IMAGE_NAME:latest tags
+          if [ "$CIRCLE_BRANCH" == "main" ]; then
+            docker manifest create $IMAGE_NAME:$VERSION --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
+            docker manifest create $IMAGE_NAME:latest --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
+            docker manifest push $IMAGE_NAME:$VERSION
+            docker manifest push $IMAGE_NAME:latest
+          fi
 workflows:
   commit:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,8 @@ jobs:
       IMAGE_NAME: polymeshassociation/polymesh-private
     docker:
       - image: cimg/deploy:2023.12
-    resource_class: arm.small
+    # this is the smallest resource class that supports arm64
+    resource_class: arm.medium
     steps:
       - setup_remote_docker
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,7 +326,7 @@ workflows:
           context:
             - DockerHub
           requires:
-            - -arm64
+            - build-arm64
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,6 @@ jobs:
           paths:
               - .
       - save-sccache-cache
-  
   build-arm64:
     docker:
       - image: polymeshassociation/rust-arm64:debian-nightly-2023-12-11
@@ -132,7 +131,6 @@ jobs:
           paths:
               - .
       - save-sccache-cache
-
   benchmark-build:
     docker:
       - image: polymeshassociation/rust:debian-nightly-2023-12-11
@@ -304,6 +302,12 @@ workflows:
       - clippy
       - test
       - build
+      - build-arm64:
+          filters:
+            branches:
+              only:
+                - main
+                - build/*
       - benchmark-build
       - coverage
       - rust-integration-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,8 @@ jobs:
           echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
           docker push --all-tags $IMAGE_NAME
   push-multiarch-image:
+    environment:
+      IMAGE_NAME: polymeshassociation/polymesh-private
     docker:
       - image: cimg/deploy:2023.12
     resource_class: small
@@ -292,6 +294,8 @@ jobs:
           at: .
       - run: |
           export VERSION=`./scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
+          docker manifest create $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
+          docker manifest push $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian
           docker manifest create $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
           docker manifest push $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ workflows:
             branches:
               only:
                 - main
-                - build/*
+                - build*
       - benchmark-build
       - coverage
       - rust-integration-test:
@@ -325,7 +325,7 @@ workflows:
             branches:
               only:
                 - main
-                - build/*
+                - build*
       - build-docker-arm64-debian:
           context:
             - DockerHub
@@ -335,7 +335,7 @@ workflows:
             branches:
               only:
                 - main
-                - build/*
+                - build*
       - push-multiarch-image:
           context:
             - DockerHub
@@ -346,4 +346,4 @@ workflows:
             branches:
               only:
                 - main
-                - build/*
+                - build*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,6 @@ workflows:
             branches:
               only:
                 - main
-                - build-ma-builds
       - benchmark-build
       - coverage
       - rust-integration-test:
@@ -337,18 +336,17 @@ workflows:
             branches:
               only:
                 - main
-                - build-ma-builds
       - build-docker-arm64-debian:
           context:
             - DockerHub
           requires:
+            # this job requires the build job to make sure it has access to all required artifacts in its workspace.
             - build
             - build-arm64
           filters:
             branches:
               only:
                 - main
-                - build-ma-builds
       - push-multiarch-image:
           context:
             - DockerHub
@@ -359,4 +357,3 @@ workflows:
             branches:
               only:
                 - main
-                - build-ma-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,35 @@ jobs:
           paths:
               - .
       - save-sccache-cache
+  
+  build-arm64:
+    docker:
+      - image: polymeshassociation/rust-arm64:debian-nightly-2023-12-11
+    resource_class: xlarge
+    environment:
+      VERBOSE: "1"
+      RUSTFLAGS: -D warnings
+      RUSTC_WRAPPER: /usr/local/cargo/bin/sccache
+    steps:
+      - checkout
+      - setup-sccache
+      - restore-sccache-cache
+      - run:
+          name: Build release
+          command: cargo build --locked --release
+          no_output_timeout: 30m
+      - run:
+          name: Create assets directory for releases
+          command: mkdir ./assets
+      - run:
+          name: Copy binary to assets
+          command: cp ./target/release/polymesh-private ./assets/polymesh-private-arm64
+      - persist_to_workspace:
+          root: ./assets
+          paths:
+              - .
+      - save-sccache-cache
+
   benchmark-build:
     docker:
       - image: polymeshassociation/rust:debian-nightly-2023-12-11
@@ -236,9 +265,36 @@ jobs:
           at: .
       - run: |
           export VERSION=`./scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
-          docker build -f ./.docker/Dockerfile.debian --tag $IMAGE_NAME:latest-$CIRCLE_BRANCH-debian --tag $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian .
+          docker build -f ./.docker/Dockerfile.debian --tag $IMAGE_NAME:latest-$CIRCLE_BRANCH-debian-amd64 --tag $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 .
           echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
           docker push --all-tags $IMAGE_NAME
+  build-docker-arm64-debian:
+    environment:
+      IMAGE_NAME: polymeshassociation/polymesh-private
+    docker:
+      - image: cimg/deploy:2023.12
+    resource_class: arm.small
+    steps:
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run: |
+          export VERSION=`./scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
+          docker build -f ./.docker/arm64/Dockerfile.debian --tag $IMAGE_NAME:latest-$CIRCLE_BRANCH-debian-arm64 --tag $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64 .
+          echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
+          docker push --all-tags $IMAGE_NAME
+  push-multiarch-image:
+    docker:
+      - image: cimg/deploy:2023.12
+    resource_class: small
+    steps:
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run: |
+          export VERSION=`./scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
+          docker manifest create $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-amd64 --amend $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian-arm64
+          docker manifest push $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH
 
 workflows:
   commit:
@@ -265,3 +321,25 @@ workflows:
             branches:
               only:
                 - main
+                - build/*
+      - build-docker-arm64-debian:
+          context:
+            - DockerHub
+          requires:
+            - -arm64
+          filters:
+            branches:
+              only:
+                - main
+                - build/*
+      - push-multiarch-image:
+          context:
+            - DockerHub
+          requires:
+            - build-docker-debian
+            - build-docker-arm64-debian
+          filters:
+            branches:
+              only:
+                - main
+                - build/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ workflows:
             branches:
               only:
                 - main
-                - build*
+                - build-ma-builds
       - benchmark-build
       - coverage
       - rust-integration-test:
@@ -325,7 +325,7 @@ workflows:
             branches:
               only:
                 - main
-                - build*
+                - build-ma-builds
       - build-docker-arm64-debian:
           context:
             - DockerHub
@@ -335,7 +335,7 @@ workflows:
             branches:
               only:
                 - main
-                - build*
+                - build-ma-builds
       - push-multiarch-image:
           context:
             - DockerHub
@@ -346,4 +346,4 @@ workflows:
             branches:
               only:
                 - main
-                - build*
+                - build-ma-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
   build-arm64:
     docker:
       - image: polymeshassociation/rust-arm64:debian-nightly-2023-12-11
-    resource_class: xlarge
+    resource_class: arm.xlarge
     environment:
       VERBOSE: "1"
       RUSTFLAGS: -D warnings

--- a/.docker/arm64/Dockerfile.debian
+++ b/.docker/arm64/Dockerfile.debian
@@ -1,0 +1,46 @@
+ARG golangbase=1.22
+FROM --platform=linux/arm64 golang:${golangbase} as gobuild
+
+ADD .docker/src/health-checks/ /opt/health-check/
+ADD .docker/src/rotate-keys/ /opt/rotate-keys/
+
+WORKDIR /opt/health-check
+RUN ls -a && \
+    go build && \
+    chmod 0755 /opt/health-check/polymesh-health-check
+
+WORKDIR /opt/rotate-keys
+RUN ls -a && \
+    go build && \
+    chmod 0755 /opt/rotate-keys/polymesh-rotate-keys
+
+FROM debian:stable-slim
+
+# explicitly set user/group IDs
+RUN set -eux; \
+	groupadd -r polymesh-private --gid=4001; \
+	useradd -r -g polymesh-private --uid=4001 -m -d /opt/polymesh-private polymesh-private; \
+	mkdir -p /opt/polymesh-private; \
+	chown -R polymesh-private:polymesh-private /opt/polymesh-private
+
+COPY --chown=4002:4002 --from=gobuild      /opt/health-check/polymesh-health-check /usr/local/bin/check
+COPY --chown=4002:4002 --from=gobuild      /opt/rotate-keys/polymesh-rotate-keys   /usr/local/bin/rotate
+COPY --chown=4001:4001 ./polymesh-private-arm64 /usr/local/bin/polymesh-private
+COPY --chown=4001:4001 ./LICENSE.pdf /opt/polymesh-private/LICENSE.pdf
+
+RUN mkdir /var/lib/polymesh-private && \
+    chown 4001:4001 /var/lib/polymesh-private
+
+USER 4001:4001
+
+WORKDIR /opt/polymesh-private
+
+ENTRYPOINT ["/usr/local/bin/polymesh-private"]
+CMD [ "-d", "/var/lib/polymesh-private" ]
+
+HEALTHCHECK \
+    --interval=10s \
+    --start-period=120s \
+    --timeout=5s \
+    --retries=6 \
+    CMD /usr/local/bin/check liveness

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6097,7 +6097,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-private"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "clap",
  "curve25519-dalek-ng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh-private"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["PolymeshAssociation"]
 build = "build.rs"
 edition = "2021"

--- a/runtime/develop/src/runtime.rs
+++ b/runtime/develop/src/runtime.rs
@@ -54,7 +54,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 1_000_010,
+    spec_version: 1_000_020,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/production/src/runtime.rs
+++ b/runtime/production/src/runtime.rs
@@ -51,7 +51,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 1_000_010,
+    spec_version: 1_000_020,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
This changes adds an `arm64` docker image build. On top of that it also creates a `multiarch docker manifest`, which once pushed adds a single image tag to cover both supported architectures. This way, the users won't need to specify the architecture explicitly as it would be matched against their runtime environment as long as it's supported.

In addition if the build happens against the main branch, additional image tags would be created, in total it creates following tags:

- `polymeshassociation/polymesh-private:[VERSION]-[BRANCH]-debian`
- `polymeshassociation/polymesh-private:[VERSION]-[BRANCH]`
- `polymeshassociation/polymesh-private:[VERSION]`
- `polymeshassociation/polymesh-private:latest`

This makes the debian image the default one, which we can modify if we want to add distroless or any other base for the docker image.

### new features

As described above

### modified external API

NA

### new external API

NA

### modified events

NA

### new events

NA

### other

NA

### data migration

NA
